### PR TITLE
correção de erros

### DIFF
--- a/Codificadores/Codifica191112127.java
+++ b/Codificadores/Codifica191112127.java
@@ -19,7 +19,7 @@ public class Codifica191112127 implements Codifica {
 
     @Override
     public String decodifica(String str) {
-        return str.substring(4, str.length() - 4);
+        return str.substring(8, str.length() - 8);
     }
 
 }

--- a/Codificadores/Codifica211010749.java
+++ b/Codificadores/Codifica211010749.java
@@ -4,12 +4,12 @@ public class Codifica211010749 implements Codifica {
 
     @Override
     public String codifica(String str) {
-        return "૮ ̷ ̷ ̷・"+ str + "ﻌ ̷ ̷・ ა";
+        return "૮ ̷ ̷ ̷・ "+ str + " ﻌ ̷ ̷・  ";  
     }
 
     @Override
     public String decodifica(String str) {
-        return str.substring(8, str.length() - 8);
+        return str.substring(14, str.length() - 14);
     }
 
     @Override


### PR DESCRIPTION
O uso do caracter especial no codigo "Codifica211010749" causava erro de compilação.  Os outros eram de lógica, pois o resultado da decodificação resultava numa frase diferente da original. 